### PR TITLE
Add script to backup MIDAS audit logs

### DIFF
--- a/config/production/mappings.yml
+++ b/config/production/mappings.yml
@@ -223,7 +223,8 @@ general:
       [ 'scripts/chado_convert_load_iprscan',	      'production_bin' ],
       [ 'scripts/run_haploview',		      'production_bin' ],
       [ 'scripts/pinto_pathdb_environment_setup.sh',  'pathdev_bin' ],
-      [ 'scripts/mash',                               'production_bin' ]
+      [ 'scripts/mash',                               'production_bin' ],
+      [ 'scripts/backup_midas_audit_logs.sh',         'pathdev_bin' ]
   ]
   splimer: [ [ 'splimer.pl', 'production_bin' ], [ 'modules/FastaLength.pm', 'production_lib' ],
   ]


### PR DESCRIPTION
Add a mapping to deploy "backup_midas_audit_logs.sh" into the pathdev bin.