### PR TITLE
add extra Python scripts requested by Uli

### DIFF
--- a/config/production/mappings.yml
+++ b/config/production/mappings.yml
@@ -18,6 +18,8 @@ general:
       [ 'scripts/fastn_split.py',                  'production_bin' ],
       [ 'scripts/get_sequencing_project_pages.py', 'production_bin' ],
       [ 'scripts/snp_sites_plink_files.py',        'production_bin' ],
+      [ 'scripts/get_annot_changes_list',          'production_bin' ],
+      [ 'scripts/push_gffdump_to_ftp.py',          'production_bin' ],
       [ 'modules/wikipy.py',                       'production_lib' ],
       [ 'modules/util',                            'production_lib' ],
       [ 'modules/gffminimal',                      'production_lib' ],


### PR DESCRIPTION
This PR adds two new Python scripts:

- `get_annot_changes_list` which produces a tab-separated list of annotation changes in GeneDB between dates, and
- `push_gffdump_to_ftp.py` which automates distribution and symlinking of bulk-dumped GFF3 data from Chado to the Sanger FTP server. 