### PR TITLE
removed old 'chado' script

### DIFF
--- a/config/production/mappings.yml
+++ b/config/production/mappings.yml
@@ -150,7 +150,6 @@ general:
       [ 'scripts/setup_test_pathpipe_environment.sh', 'pathdev_bin' ],
       [ 'scripts/concatgff.sh',                       'pathdev_bin' ],
       [ 'scripts/tmhmm_chado',                        'production_bin' ],
-      [ 'scripts/chado',                              'production_bin' ],
       [ 'scripts/writedb_entry',                      'production_bin' ],
       [ 'scripts/chado_dump_transcripts',             'production_bin' ],
       [ 'scripts/chado_dump_genome',                  'production_bin' ],


### PR DESCRIPTION
because it conceals the executable of the 'chado-tools' on the path