### PR TITLE
add pathdev_config and database connection details

### DIFF
--- a/config/production/global.yml
+++ b/config/production/global.yml
@@ -2,7 +2,7 @@ general:
   repository:
     url: 'git@gitlab.internal.sanger.ac.uk:sanger-pathogens/general.git'
     branch: 'master'
-  directories_to_build: ['java','perl','python','shell','c','lua','splimer','r','data']
+  directories_to_build: ['java','perl','python','shell','c','lua','splimer','r','data', 'config']
 
 checkout_directory: "/tmp"
 
@@ -10,7 +10,8 @@ directories:
   production_bin:    '/software/pathogen/internal/prod/bin'
   production_lib:    '/software/pathogen/internal/prod/lib'
   pathdev_lib:       '/software/pathogen/internal/pathdev/lib'
-  pathdev_bin:       '/software/pathogen/internal/pathdev/bin'  
+  pathdev_bin:       '/software/pathogen/internal/pathdev/bin' 
+  pathdev_config:    '/software/pathogen/config' 
   preproduction_bin: '/software/pathogen/internal/preprod/bin'
   preproduction_lib: '/software/pathogen/internal/preprod/lib'
   production_java:   '/software/pathogen/internal/pathdev/java'

--- a/config/production/mappings.yml
+++ b/config/production/mappings.yml
@@ -141,6 +141,11 @@ general:
         [ 'adapters/solexa-adapters.quasr', 'production_etc' ],
   ]
 
+  config: [
+        [ 'database_connection_details', 'pathdev_config' ],
+        [ 'reftrack_connection_details', 'pathdev_config' ],
+  ]
+
   shell: [
       [ 'scripts/sourmash',                           'production_bin'],
       [ 'scripts/genus_genbank_to_blast',             'pathdev_bin' ],

--- a/config/test/global.yml
+++ b/config/test/global.yml
@@ -2,7 +2,7 @@ general:
   repository:
     url: 'git@gitlab.internal.sanger.ac.uk:sanger-pathogens/general.git'
     branch: 'master'
-  directories_to_build: ['perl','java','python','shell']
+  directories_to_build: ['perl','java','python','shell','config']
 
 checkout_directory: "/tmp/deployment_test"
 
@@ -10,7 +10,8 @@ directories:
   production_bin:    '/tmp/deployment_test'
   production_lib:    '/tmp/deployment_test'
   pathdev_lib:       '/tmp/deployment_test'
-  pathdev_bin:       '/tmp/deployment_test'
+  pathdev_bin:       '/tmp/deployment_test' 
+  pathdev_config:    '/software/pathogen/config' 
   preproduction_bin: '/tmp/deployment_test'
   preproduction_lib: '/tmp/deployment_test'
   production_java:   '/tmp/deployment_test'

--- a/config/test/mappings.yml
+++ b/config/test/mappings.yml
@@ -76,3 +76,8 @@ general:
             ['scripts/extract_chado_annotation_updates.sh', 'pathdev_bin'],
             ['scripts/import_chado_go_terms.sh',           'pathdev_bin']
         ]
+
+  config: [
+            [ 'database_connection_details', 'pathdev_config' ],
+            [ 'reftrack_connection_details', 'pathdev_config' ],
+        ]


### PR DESCRIPTION
Linked to https://gitlab.internal.sanger.ac.uk/sanger-pathogens/general/merge_requests/81

Add pathdev_config to test and production
Track database connection files in /software/pathogen/config 