### PR TITLE
Changing send_new_starter_emails so doesn't have to be sent from path…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: perl
 sudo: false
 install:
-  - cpanm Getopt::Long Net::SCP Git::Repository YAML::XS Time::Mock File::Slurp Date::Parse 
+  - cpanm Getopt::Long Test::Most Net::SCP Git::Repository YAML::XS Time::Mock File::Slurp Date::Parse 
 script:
   - make test

--- a/config/local/mappings.yml
+++ b/config/local/mappings.yml
@@ -175,7 +175,7 @@ general:
         [ 'scripts/pathpipe-pathpipe-farm3_crontab',	'pathdev_bin' ],
         [ 'scripts/pathdb_farm3_crontab',		'pathdev_bin' ],
         [ 'scripts/setup_seroba_dbs.sh',		'pathdev_bin' ],
-	[ 'scripts/send_new_starter_emails.sh',		'pathdev_bin' ],
+	[ 'scripts/send_new_starter_emails.sh',		'production_bin' ],
 	[ 'scripts/setup_pathogen_profile.sh',		'production_bin' ],
         [ 'scripts/skesa',				'production_bin' ],
         [ 'scripts/sourmash',				'production_bin' ],

--- a/config/test/mappings.yml
+++ b/config/test/mappings.yml
@@ -184,7 +184,7 @@ general:
         [ 'scripts/pathpipe-pathpipe-farm3_crontab',	'pathdev_bin' ],
         [ 'scripts/pathdb_farm3_crontab',		'pathdev_bin' ],
         [ 'scripts/setup_seroba_dbs.sh',		'pathdev_bin' ],
-	[ 'scripts/send_new_starter_emails.sh',         'pathdev_bin' ],
+	[ 'scripts/send_new_starter_emails.sh',         'production_bin' ],
 	[ 'scripts/setup_pathogen_profile.sh',          'production_bin' ],
         [ 'scripts/skesa',				'production_bin' ],
         [ 'scripts/sourmash',				'production_bin' ],


### PR DESCRIPTION
Changed send_new_starter_emails script from pathdev_bin to production_bin so that anyone can send the emails, doesn't have to be as path pipe. This means everyone in the team doesn't get emails every time  